### PR TITLE
ConvNet Notebook: Enlist additional steps for new Kaggle users

### DIFF
--- a/5-DL-for-computer-vision/8.introduction-to-convnets.ipynb
+++ b/5-DL-for-computer-vision/8.introduction-to-convnets.ipynb
@@ -1379,7 +1379,9 @@
     "The dataset is available on [Kaggle](https://www.kaggle.com/c/dogs-vs-cats/data), and DLWP has a procedure to download it in Colab (pp.212-213):\n",
     "\n",
     "1. Create a Kaggle account (free)\n",
-    "2. Go to [settings](https://www.kaggle.com/settings), create a token (`.json` file), download it locally and upload it to the main Colab folder. The code below expects that.\n"
+    "2. Go to [settings](https://www.kaggle.com/settings), create a token (`.json` file), download it locally and upload it to the main Colab folder. The code below expects that.\n",
+    "3. Verify your phone number within [Kaggle Profile Settings](https://www.kaggle.com/settings)\n",
+    "4. Go to the [Dogs vs Cats dataset](https://www.kaggle.com/c/dogs-vs-cats/data) and join the competition.\n"
    ]
   },
   {


### PR DESCRIPTION
Kaggle requires an additional step of having a verified phone number which in turn would allow one to join the competition and access the dataset with the prescribed workflow.